### PR TITLE
Specify chromedriver version in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ jdk: oraclejdk8
 sudo: required
 addons:
   chrome: stable
+before_script:
+  - chromedriver-update 75.0.3770.8
 before_install:
   - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost:8080 &
 script:


### PR DESCRIPTION
Travis is using a ChromeDriver version which specifically asks for Chrome 76 which is still in the dev channel. This sets the ChromeDriver version so we can keep using Chrome's stable channel